### PR TITLE
Added multi pixel support & unit tests

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,10 @@
 homepage: "https://business.nextdoor.com/enterprise"
 documentation: "https://help.nextdoor.com/s/article/About-Neighborhood-Ad-Center-NAC-Conversion-Pixel"
 versions:
+  # Latest version
+  - sha: 5d7822d4f1f3908c45759fdef58a2e7b4947b2a1
+    changeNotes: Added optional multiple Pixel ID inputs.
+  # Older versions
   - sha: 9e5659558173ae7e5c555937dff0b7c3d14102c0
     changeNotes: Log fixes
   - sha: b108e04c8dcea2cace812778436677a7877d05cf


### PR DESCRIPTION
This PR introduces changes to the Nextdoor Pixel GTM custom template that enable the multi pixel feature support.

Updated the regex for Pixel IDs: each pixel id should be UUID that consists of 32 hexadecimal characters, separated by hyphens into five groups of 8-4-4-4-12 characters respectively. The string may begin and end with any number of whitespace characters, and each UUID, except for the last one, can be followed by a comma and any number of whitespace characters.

Each passed Pixel ID will be initialized and added to the Pixel ID array. Then every Pixel ID will be sent to the tracking call.

Slightly not backwards compatible however. For advertisers who currently have 1 pixel id in GTM but 2 pixels installed, it will double count, this change will immediately only count the one. The reason I opted against an additional parameter, is it seemed redundant/confusing to include the Pixel ID in one field and then create a list with that ID as well.

It also adds unit tests, that setup the Pixel script injection and multi pixel parameter extraction.