### PR TITLE
Added custom data

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,9 +16,11 @@ homepage: "https://business.nextdoor.com/enterprise"
 documentation: "https://help.nextdoor.com/s/article/About-Neighborhood-Ad-Center-NAC-Conversion-Pixel"
 versions:
   # Latest version
+  - sha: f5955dc5f87c160a2f9668ea60a1eaa7561f7bbb
+    changeNotes: Add optional Custom Data field.
+  # Older versions
   - sha: 306a417502ca873a6320a1f5ce36b2da41eb704e
     changeNotes: Add optional Event ID field.
-  # Older versions
   - sha: 5d7822d4f1f3908c45759fdef58a2e7b4947b2a1
     changeNotes: Added optional multiple Pixel ID inputs.
   - sha: 9e5659558173ae7e5c555937dff0b7c3d14102c0


### PR DESCRIPTION
- Added custom data fields to Pixel GTM template
- Tested with unit test & test website
- See this [page](https://coda.io/d/Ads-Measurement_d2l6PE9eR8a/Pixel-Fields_suDE0#Event-Parameters_tu1lp) for more info on the fields

<img width="913" alt="Screenshot 2023-09-21 at 4 24 41 PM" src="https://github.com/Nextdoor/nextdoor-google-tag-manager/assets/124309126/5fa5eeb3-3193-4b88-a674-0919fdf6bb80">

<img width="949" alt="Screenshot 2023-09-21 at 4 02 09 PM" src="https://github.com/Nextdoor/nextdoor-google-tag-manager/assets/124309126/7a3bfd1a-3dc5-485a-807a-f9a9cfaf5cbd">


