### PR TITLE
fix - address empty event name

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,9 +17,11 @@ documentation: "https://help.nextdoor.com/s/article/About-Neighborhood-Ad-Center
 versions:
 
   # Latest version
+  - sha: a2a2ea8266a3fc5a3af1ff73c9b28ca11bc1c702
+    changeNotes: Addressing empty event name issue.
+  # Older versions
   - sha: 1abd58009687c449d579d55601740c07f1d5dc8d
     changeNotes: Update Logo. Display event name in summary.
-  # Older versions
   - sha: 913104ed95bb881a197f84dc7c6244117babc2a5
     changeNotes: Update RDU help text
   - sha: 66fffe8e39a62a58642fcf2bb144f13f9ed81e30

--- a/template.tpl
+++ b/template.tpl
@@ -206,7 +206,8 @@ ___TEMPLATE_PARAMETERS___
         ]
       }
     ],
-    "simpleValueType": true
+    "simpleValueType": true,
+    "defaultValue": "standard"
   },
   {
     "type": "GROUP",
@@ -532,16 +533,16 @@ function bootstrap() {
     });
   }
 
-  var event_name_final = null;
-  if (initData.event_name == 'standard') {
-    event_name_final = initData.standard_event_name;
+  var event_name_final = 'PAGE_VIEW';
+  if (initData.event_name == 'variable') {
+    event_name_final = initData.variable_event_name;
   } else if (initData.event_name == 'custom') {
     event_name_final = initData.custom_event_name;
     if (data.custom_event_nickname) {
       event_params.nickname = data.custom_event_nickname;
     }
   } else {
-    event_name_final = initData.variable_event_name;
+    event_name_final = initData.standard_event_name;
   }
 
   ndp('track', event_name_final, event_params, custom_data);


### PR DESCRIPTION
This pull request addresses an issue with empty event names, introduces a default value for template parameters, and updates the logic for determining the final event name in the `bootstrap` function. Below is a summary of the most important changes:

### Metadata Updates:
* Added a new version entry in `metadata.yaml` with SHA `a2a2ea8266a3fc5a3af1ff73c9b28ca11bc1c702` and change notes describing the fix for the empty event name issue.

### Template Parameter Enhancements:
* Updated `template.tpl` to include a `defaultValue` property set to `"standard"` in the template parameters.

### Event Name Logic Refinement:
* Refactored the `bootstrap` function in `template.tpl` to:
  - Set the default `event_name_final` to `"PAGE_VIEW"`.
  - Adjust the logic to correctly handle cases where `event_name` is `"standard"`, `"variable"`, or `"custom"`. This ensures the appropriate event name is assigned based on the input data.