### PR TITLE
fix - empty event name patch

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,9 +17,11 @@ documentation: "https://help.nextdoor.com/s/article/About-Neighborhood-Ad-Center
 versions:
 
   # Latest version
+  - sha: c9653cca9720f19aa887eb6bf71d7f33fbfad508
+    changeNotes: Second attempt of addressing empty event name issue.
+  # Older versions
   - sha: a2a2ea8266a3fc5a3af1ff73c9b28ca11bc1c702
     changeNotes: Addressing empty event name issue.
-  # Older versions
   - sha: 1abd58009687c449d579d55601740c07f1d5dc8d
     changeNotes: Update Logo. Display event name in summary.
   - sha: 913104ed95bb881a197f84dc7c6244117babc2a5

--- a/template.tpl
+++ b/template.tpl
@@ -533,7 +533,7 @@ function bootstrap() {
     });
   }
 
-  var event_name_final = 'PAGE_VIEW';
+  var event_name_final = null;
   if (initData.event_name == 'variable') {
     event_name_final = initData.variable_event_name;
   } else if (initData.event_name == 'custom') {
@@ -545,6 +545,11 @@ function bootstrap() {
     event_name_final = initData.standard_event_name;
   }
 
+  event_name_final = event_name_final || 'PAGE_VIEW';
+
+  log('[ND] event_name_final = ', event_name_final);
+  log('[ND] event_params = ', event_params);
+  log('[ND] custom_data = ', custom_data);
   ndp('track', event_name_final, event_params, custom_data);
 
   var url = 'https://ads.nextdoor.com/public/pixel/ndp.js?id=' + multi_pixel_list[0];


### PR DESCRIPTION
This pull request addresses issues related to handling empty event names in the `template.tpl` file and updates the version history in `metadata.yaml`. The most important changes include ensuring a fallback value for `event_name_final`, adding debug logs for better traceability, and documenting the changes in the metadata.

### Event name handling improvements:
* [`template.tpl`](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292L536-R536): Changed the default value of `event_name_final` to `null` and added a fallback assignment to `'PAGE_VIEW'` if no valid event name is provided. This ensures that the event name is never empty. [[1]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292L536-R536) [[2]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292R548-R552)
* [`template.tpl`](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292R548-R552): Added debug logs for `event_name_final`, `event_params`, and `custom_data` to aid in debugging and monitoring.

### Metadata updates:
* [`metadata.yaml`](diffhunk://#diff-d186204ea7abb85bbadd9d94ab29d5bcefcc43d6a0ed06015e98a71b2f099423R20-L22): Added a new version entry with the change notes "Second attempt of addressing empty event name issue" to document the updates made in this pull request.